### PR TITLE
Allow recursive glob with "**"

### DIFF
--- a/scripts/import.py
+++ b/scripts/import.py
@@ -36,7 +36,7 @@ def main():
     db = Database(config, args.dbname).connect()
 
     # iterate over matching files on the filesystem
-    for f in glob.iglob(args.expr):
+    for f in glob.iglob(args.expr, recursive=True):
         dirname = os.path.dirname(f)
         basename = os.path.basename(f)
         # probe for dpdash-compatibility and gather information


### PR DESCRIPTION
Per https://docs.python.org/3/library/glob.html#glob.glob:
> If _recursive_ is true, the pattern “`**`” will match any files and zero or more directories, subdirectories and symbolic links to directories.

Example use matching all of my CSVs in any subdirectory of `/dpdash-data`:
```sh
import.py -c ./config.yml '/home/bls64/dpdash-data/**/*.csv'
```

Introduced in Python 3.5 so that would become the minimum required version.