### PR TITLE
Fix re-import issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ simple [`glob`](https://en.wikipedia.org/wiki/Glob_(programming)) expression.
 ## Table of contents
 1. [Installation](#installation)
 2. [Configuration](#configuration)
+   - [MongoDB](#mongodb)
 3. [Usage](#usage)
 
 ## Installation
@@ -16,9 +17,18 @@ pip install git+https://github.com/harvard-nrg/dpimport
 ```
 
 ## Configuration
-DPimport requires a configuration file `-c|--config` for establishing a database 
+DPimport requires a configuration file in YAML format, passed as a command
+line argument with `-c|--config`, for establishing a MongoDB database 
 connection. You will find an example configuration file in the `examples` 
 directory within this repository.
+
+### MongoDB
+
+This tool requires MongoDB to be running and accessible with the credentials you
+supply in the YAML config file.
+
+For tips on MongoDB as it is used in DPdash and DPimport, see 
+[the DPdash wiki](https://github.com/PREDICT-DPACC/dpdash/wiki/MongoDB-Tips).
 
 ## Usage
 The main command line tool is `import.py`. You can use this tool to import any

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import.py -c config.yml '/PHOENIX/GENERAL/**/processed/*.csv'
 
 and so on.
 
-<detail>
+<details>
 <summary>More information on **</summary>
 
 `directory/*/*.csv` matches only `directory/[subdirectory]/[filename].csv`. With a [recursive glob pattern](https://docs.python.org/3/library/glob.html#glob.glob), `directory/**/*.csv` will additionally match:
@@ -53,4 +53,4 @@ and so on.
 
 and so on, for as many levels deep as exist in the directory tree.
 
-</detail>
+</details>

--- a/README.md
+++ b/README.md
@@ -29,3 +29,28 @@ or a glob expression (use single quotes to avoid shell expansion)
 import.py -c config.yml '/PHOENIX/GENERAL/STUDY_A/SUB_001/DATA_TYPE/processed/*.csv'
 ```
 
+You may also now use the `**` recursive glob expression, for example:
+
+```bash
+import.py -c config.yml '/PHOENIX/**/*.csv'
+```
+
+or
+
+```bash
+import.py -c config.yml '/PHOENIX/GENERAL/**/processed/*.csv'
+```
+
+and so on.
+
+<detail>
+<summary>More information on **</summary>
+
+`directory/*/*.csv` matches only `directory/[subdirectory]/[filename].csv`. With a [recursive glob pattern](https://docs.python.org/3/library/glob.html#glob.glob), `directory/**/*.csv` will additionally match:
+
+* `directory/[filename].csv` (no subdirectory)
+* `directory/[subdirectory1]/[subdirectory2]/[filename].csv` (sub-subdirectory)
+
+and so on, for as many levels deep as exist in the directory tree.
+
+</detail>

--- a/dpimport/__init__.py
+++ b/dpimport/__init__.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import mimetypes as mt
 from . import patterns
+from dppylib import diff_files
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ def probe(path):
     :type path: str
     '''
     if not os.path.exists(path):
-        logger.debug('file not found %s', f)
+        logger.debug('file not found %s', path)
         return None
     dirname = os.path.dirname(path)
     basename = os.path.basename(path)

--- a/dppylib/__init__.py
+++ b/dppylib/__init__.py
@@ -132,13 +132,32 @@ def insert_data(db, file_info):
         # Import data
         data_blob = []
         import_collection = db[file_info['collection']]
+        # Check for min and max day in collection
+        min_day = float('inf')
+        max_day = -1
+        min_day_found = import_collection.find_one({'day': {'$exists': True}}, sort=[('day', 1)], projection= {'day': 1})
+        if min_day_found is not None:
+            min_day = min_day_found['day']
+        max_day_found = import_collection.find_one({'day': {'$exists': True}}, sort=[('day', -1)], projection= {'day': 1})
+        if max_day_found is not None:
+            max_day = max_day_found['day']
         for chunk in reader.read_csv(file_info['path']):
             if len(chunk) > 0:
                 if file_info['role'] != 'metadata':
                     chunk_columns = sanitize_columns(chunk.columns.values.tolist())
                     chunk.columns = chunk_columns
                 chunk['path'] = file_info['path']
-                data_blob.extend(chunk.to_dict('records'))
+                if 'day' in chunk: 
+                    chunk_day = int(chunk['day'])
+                    # Add to data blob if there is no existing day range for this collection
+                    if min_day_found is None or max_day_found is None:
+                        data_blob.extend(chunk.to_dict('records'))
+                    # Add to data blob if this day not in existing range
+                    elif (chunk_day < min_day) or (chunk_day > max_day):
+                        data_blob.extend(chunk.to_dict('records'))
+                # Add to data blob if there's no day column (e.g. metadata CSVs)
+                else:
+                    data_blob.extend(chunk.to_dict('records'))
 
                 if len(data_blob) >= 100000:
                     import_collection.insert_many(data_blob, False)

--- a/dppylib/__init__.py
+++ b/dppylib/__init__.py
@@ -149,11 +149,9 @@ def insert_data(db, file_info):
                 chunk['path'] = file_info['path']
                 if 'day' in chunk: 
                     chunk_day = int(chunk['day'])
-                    # Add to data blob if there is no existing day range for this collection
-                    if min_day_found is None or max_day_found is None:
-                        data_blob.extend(chunk.to_dict('records'))
-                    # Add to data blob if this day not in existing range
-                    elif (chunk_day < min_day) or (chunk_day > max_day):
+                    # Add to data blob if there is no existing day range for this collection,
+                    # or if this day is not in the existing range
+                    if min_day_found is None or max_day_found is None or (chunk_day < min_day) or (chunk_day > max_day):
                         data_blob.extend(chunk.to_dict('records'))
                 # Add to data blob if there's no day column (e.g. metadata CSVs)
                 else:

--- a/scripts/import.py
+++ b/scripts/import.py
@@ -49,12 +49,6 @@ def main():
             logger.info('document exists and is up to date %s', probe['path'])
             continue
         logger.info('document does not exist or is out of date %s', probe['path'])
-        # mark matching documents as unsynced (probably unnecessary)
-        logger.info('flipping sync to false for documents matching %s', probe['glob'])
-        db.unsync(probe['glob'])
-        # remove unsynced documents
-        logger.info('removing all unsynced documents matching %s', probe['glob'])
-        db.remove_unsynced(probe['glob'])
         # import the file
         logger.info('importing file %s', f)
         dppylib.import_file(db.db, probe)


### PR DESCRIPTION
Closes #4, closes #5

- Import all files, but only add a given row to relevant collection if `day` is out of existing range
  - Prevents accidental overwriting of data, ensures that all CSV files are actually reflected in data
- Remove code that deletes DB entries for other `day*.csv`
  - With this code removed, each file should only import once
- Fix minor undefined warnings (in `dpimport/__init__.py`)
- Add recursive glob info to `README.md`

Tested by dropping `dpdata` MongoDB database and importing all data, then running dpimport again to ensure no re-imports.