### PR TITLE
Re-import only changed files

### DIFF
--- a/dpimport/__init__.py
+++ b/dpimport/__init__.py
@@ -39,6 +39,11 @@ def probe(path):
     # add other necessary information to info object
     mimetype,encoding = mt.guess_type(path)
     stat = os.stat(path)
+
+    with open(path) as f:
+        content = f.read().strip()
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+    
     info.update({
         'path' : path,
         'filetype' : mimetype,
@@ -52,7 +57,8 @@ def probe(path):
         'uid' : stat.st_uid,
         'gid' : stat.st_gid,
         'mode' : stat.st_mode,
-        'role': role
+        'role': role,
+        'content': content_hash
     })
     return info
 

--- a/dpimport/database/__init__.py
+++ b/dpimport/database/__init__.py
@@ -68,8 +68,7 @@ class Database(object):
         :type probe: dict
         '''
         doc = self.db.toc.find_one({
-            'path': probe['path'],
-            'size': probe['size']
+            'content': probe['content'],
         })
         if doc:
             return True

--- a/dpimport/database/__init__.py
+++ b/dpimport/database/__init__.py
@@ -68,8 +68,14 @@ class Database(object):
         :type probe: dict
         '''
         doc = self.db.toc.find_one({
-            'content': probe['content'],
+            'content': probe['content']
         })
+        if not doc:
+            # since it's not in data, check if it's in metadata
+            doc = self.db.metadata.find_one({
+                'content': probe['content']
+            })
+
         if doc:
             return True
         return False

--- a/dppylib/__init__.py
+++ b/dppylib/__init__.py
@@ -35,6 +35,10 @@ def stat_file(import_dir, file_name, file_path):
     if not os.path.exists(file_path):
         return None
 
+    with open(file_path) as f:
+        content = f.read().strip()
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+
     file_stat = os.stat(file_path)
     file_info.update({
         'path' : file_path,
@@ -48,7 +52,8 @@ def stat_file(import_dir, file_name, file_path):
         'size' : file_stat.st_size,
         'uid' : file_stat.st_uid,
         'gid' : file_stat.st_gid,
-        'mode' : file_stat.st_mode
+        'mode' : file_stat.st_mode,
+        'content' : content_hash
     })
 
     return file_info
@@ -72,7 +77,7 @@ def diff_files(db, collection, file_info):
         logger.info('{FILE} does not exist in the database. Importing.'.format(FILE=file_path))
         import_data(db, collection, file_info)
     else:
-        if db_data['mtime'] != file_info['mtime'] or db_data['size'] != file_info['size']:
+        if db_data['content'] != file_info['content']:
             logger.info('{FILE} has been modified. Re-importing.'.format(FILE=file_path))
             dbtools.remove_doc(db, collection, db_data, file_info['role'])
             import_data(db, collection, file_info)


### PR DESCRIPTION
* Re-import only changed CSVs
* Determine if changed via sha256 content hash
* Store the hash in MongoDB for comparing against old hash on the next day


This PR will significantly improve performance as 60,000 `formqc/*csv` files will not have to be re-imported nightly.